### PR TITLE
Allow multiple hooks objects, create types file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,18 +1,19 @@
 module.exports = {
-  parser: '@typescript-eslint/parser', // Specifies the ESLint parser
-  extends: [
-    'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-    'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
-    'plugin:prettier/recommended' // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
-  ],
-  parserOptions: {
-    ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
-    sourceType: 'module' // Allows for the use of imports
-  },
-  rules: {
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-use-before-define': 'off',
-    '@typescript-eslint/no-non-null-assertion': 'off'
-  }
+    parser: '@typescript-eslint/parser', // Specifies the ESLint parser
+    extends: [
+        'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+        'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+        'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    ],
+    parserOptions: {
+        ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+        sourceType: 'module', // Allows for the use of imports
+    },
+    rules: {
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-use-before-define': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-var-requires': 'off',
+    },
 }

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const withHooks = useHooks({
 3. useHooks returns a function withHooks. Pass your **async** lambda into the withHooks function to decorate your lambda and then export as normal.
 
 ```javascript
-const  handler = async (event, context) => {...}
+const handler = async (event, context) => {...}
 
 exports.handler = withHooks(handler)
 ```

--- a/src/hooks/handleScheduledEvent.ts
+++ b/src/hooks/handleScheduledEvent.ts
@@ -1,4 +1,4 @@
-import { HookCreator } from '../index'
+import { HookCreator } from '../types/hooks'
 
 export const handleScheduledEvent: HookCreator = () => async state => {
     const { event } = state

--- a/src/hooks/handleUnexpectedError.ts
+++ b/src/hooks/handleUnexpectedError.ts
@@ -1,4 +1,4 @@
-import { HookCreator } from '../index'
+import { HookCreator } from '../types/hooks'
 
 export const handleUnexpectedError: HookCreator = () => async state => {
     const { error } = state

--- a/src/hooks/logEvent.ts
+++ b/src/hooks/logEvent.ts
@@ -1,4 +1,4 @@
-import { HookCreator } from '../index'
+import { HookCreator } from '../types/hooks'
 
 export const logEvent: HookCreator = () => async state => {
     console.log(`received event: ${state.event}`)

--- a/src/hooks/parseEvent.ts
+++ b/src/hooks/parseEvent.ts
@@ -1,4 +1,4 @@
-import { HookCreator } from '../index'
+import { HookCreator } from '../types/hooks'
 
 export const parseEvent: HookCreator = () => async state => {
     const { event } = state

--- a/src/hooks/validateEventBody.ts
+++ b/src/hooks/validateEventBody.ts
@@ -1,6 +1,6 @@
 import { ObjectSchema } from 'yup'
 
-import { HookCreator } from '../index'
+import { HookCreator } from '../types/hooks'
 
 interface Config {
     requestSchema: ObjectSchema

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import { Context } from 'aws-lambda'
 
+import { Event, HooksObject, UseHooks, UseHooksState } from './types/hooks'
+import { combineHooks } from './utils'
+import { defaultHook } from './utils/defaultHook'
+
 export {
     handleScheduledEvent,
     handleUnexpectedError,
@@ -8,62 +12,28 @@ export {
     validateEventBody,
 } from './hooks'
 
-interface Hooks {
-    before?: HookHandler[]
-    after?: HookHandler[]
-    onError?: HookHandler[]
-}
-
-type Response = any
-type Event = any
-
-interface State {
-    event: Event
-    context: Context
-    exit: boolean
-    response?: Response
-    error?: Error
-}
+export * from './types/hooks'
 
 /**
- * @param config optional configuration object for this hook
- * @returns HookHandler
- */
-export type HookCreator<Config = {}> = (config?: Config) => HookHandler
-/**
- * @param state a state object that might be manipulated by this function
- * @param state.event event passed in from AWS
- * @param state.context context passed in from AWS
- * @param state.exit defaults to false, if set to true program will exit early after ivocation of this hook
- * @param state.response returned when state.exit is set to true
- * @param state.error exists only if there's an unhandled exception thrown inside a hook or the lambda
- * @returns Promise<state>
- */
-type HookHandler = (state: State) => Promise<State>
-
-type UseHooks = (hooks: Hooks) => WithHooks
-type WithHooks = (lambda: any) => (event: any, context: Context) => Promise<any>
-/**
- * Using the provided hooks create an withHooks higher order function
- * @param hooks a config object of the hooks to apply to your lambda
- * @param hooks.before an array of hooks to run before the provided lambda
- * @param hooks.after an array of hooks to run after the provided lambda
- * @param hooks.onError an array of hooks to run only if there's an error during the execution
+ * Using the provided hooks create an `withHooks` higher order function
+ * @param hooks a variadic array of config objects containing the hooks to apply to your lambda. Each config object can contain `before`, `after` and `onError` arrays
  * @returns WithHooks() function that wraps around your lambda
  */
-export const useHooks: UseHooks = (hooks: Hooks): WithHooks => {
-    if (!hooks.before) hooks.before = []
-    if (!hooks.after) hooks.after = []
-    if (!hooks.onError) hooks.onError = []
+export const useHooks: UseHooks = (...hooksArr) => {
+    if (!hooksArr) {
+        hooksArr = [defaultHook]
+    }
+
+    const hooks: HooksObject = combineHooks(hooksArr)
 
     /**
      * Higher order function that takes a lambda function
      * as input and applies the hooks provided to useHooks()
      * @param lambda lambda function
-     * @returns supercharged lambda  🚀
+     * @returns supercharged lambda 🚀
      */
     const withHooks = (lambda: any) => async (event: Event, context: Context) => {
-        let state: State = { event, context, exit: false }
+        let state: UseHooksState = { event, context, exit: false }
 
         try {
             for (const hook of hooks.before!) {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,0 +1,47 @@
+import { Context } from 'aws-lambda'
+
+/**
+ * `before`: an array of hooks to run before the provided lambda
+ *
+ * `after` an array of hooks to run after the provided lambda
+ *
+ * `onError` an array of hooks to run only if there's an error during the execution
+ */
+export interface HooksObject {
+    before: HookHandler[]
+    after: HookHandler[]
+    onError: HookHandler[]
+}
+
+export type PartialHooksObject = Partial<HooksObject>
+
+/**
+ * @param config optional configuration object for this hook
+ * @returns HookHandler
+ */
+export type HookCreator<Config = {}> = (config?: Config) => HookHandler
+
+export type Response = any
+export type Event = any
+
+export interface UseHooksState {
+    event: Event
+    context: Context
+    exit: boolean
+    response?: Response
+    error?: Error
+}
+
+/**
+ * @param state a state object that might be manipulated by this function
+ * @param state.event event passed in from AWS
+ * @param state.context context passed in from AWS
+ * @param state.exit defaults to false, if set to true program will exit early after ivocation of this hook
+ * @param state.response returned when state.exit is set to true
+ * @param state.error exists only if there's an unhandled exception thrown inside a hook or the lambda
+ * @returns Promise<state>
+ */
+export type HookHandler = (state: UseHooksState) => Promise<UseHooksState>
+
+export type UseHooks = (...hooks: PartialHooksObject[]) => WithHooks
+export type WithHooks = (lambda: any) => (event: any, context: Context) => Promise<any>

--- a/src/utils/defaultHook.ts
+++ b/src/utils/defaultHook.ts
@@ -1,0 +1,7 @@
+import { HooksObject } from '../types/hooks'
+
+export const defaultHook: HooksObject = {
+    before: [],
+    after: [],
+    onError: [],
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,20 @@
+import { HooksObject, PartialHooksObject } from '../types/hooks'
+import { defaultHook } from './defaultHook'
+
+/**
+ * Combine a number of hooksObjects into a single hooksObject
+ * @param hooks The hooks to be combined
+ */
+export const combineHooks = (hooks: PartialHooksObject[]): HooksObject => {
+    return hooks.reduce<HooksObject>((result, hook) => {
+        // Add any missing properties
+        const newHook: HooksObject = { ...defaultHook, ...hook }
+
+        // Combine the result and the current hooksObject
+        return {
+            before: [...result.before, ...newHook.before],
+            after: [...result.after, ...newHook.after],
+            onError: [...result.onError, ...newHook.onError],
+        }
+    }, defaultHook)
+}


### PR DESCRIPTION
This PR adds the ability to provide multiple configuration objects to `useHooks`, which helps with hook re-usability. For example:

```js
const { useHooks } = require('lambda-hooks')

const loggingHook = require('./logging-hook')
const parseHook = require('./parse-hook')

const withHooks = useHooks(loggingHook, parseHook, /* Your other hooks objects */ )
exports.handler = withHooks(myLambda)
```

As part of this PR, I also created a new "types" folder, to reduce pollution of the "index.ts" file